### PR TITLE
Ajout règle UFW : ouverture de port personnalisé

### DIFF
--- a/hardening/ufw_rules.sh
+++ b/hardening/ufw_rules.sh
@@ -13,7 +13,7 @@ ufw default deny incoming
 ufw default allow outgoing
 
 log "Ouverture SSH (port 22)"
-ufw allow 22/tcp
+ufw allow $(SSH_PORT)
 
 # Exemple si tu veux autoriser HTTP/HTTPS plus tard :
 # ufw allow 80/tcp


### PR DESCRIPTION
- Ajout d’une règle UFW permettant l’ouverture d’un port spécifique.
- Mise à jour du script d’installation pour intégrer cette configuration.
- Testé sur Ubuntu 22.04.
